### PR TITLE
Require newer version of requests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 elasticsearch-curator = "*"
+requests = ">=2.20.0"
 
 [dev-packages]
 


### PR DESCRIPTION
This change is in response to a GitHub automated security scan. The currently pinned version of requests has a medium-severity security vulnerability